### PR TITLE
Troubleshooting quay builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,7 +11,7 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& microdnf clean all \
 	&& mkdir -p /compile \
 	&& useradd compile \
-	&& chown -Rc /compile
+	&& chown -Rc compile:compile /compile
 USER	compile
 COPY	Makefile *.c *.h /compile/
 RUN	make -C /compile

--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,9 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& mkdir -p /compile
 WORKDIR /compile
 COPY	Makefile *.c *.h /compile
+RUN	make --version
+RUN	gcc --version
+RUN	ls -l
 RUN	make
 RUN	mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
 	&& cp -v /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 dest/lib64 \

--- a/Containerfile
+++ b/Containerfile
@@ -10,11 +10,11 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& microdnf -y install make gcc \
 	&& microdnf clean all \
 	&& mkdir -p /compile
-RUN	ls -l
-COPY	Makefile *.c *.h /compile
+RUN	ls -l && pwd
+COPY	Makefile *.c *.h /compile/
 RUN	make --version
 RUN	gcc --version
-RUN	make
+RUN	make -C /compile
 WORKDIR /compile
 RUN	mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
 	&& cp -v /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 dest/lib64 \

--- a/Containerfile
+++ b/Containerfile
@@ -10,12 +10,12 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& microdnf -y install make gcc \
 	&& microdnf clean all \
 	&& mkdir -p /compile
-WORKDIR /compile
+RUN	ls -l
 COPY	Makefile *.c *.h /compile
 RUN	make --version
 RUN	gcc --version
-RUN	ls -l
 RUN	make
+WORKDIR /compile
 RUN	mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
 	&& cp -v /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 dest/lib64 \
 	&& cp -v $COMMAND dest/

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,7 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& sed -i 's/enabled=1/enabled=0/' /etc/dnf/plugins/subscription-manager.confs)  \
 	|| true \
 	&& rm -f /etc/yum.repos.d/redhat.repo \ 
-	&& microdnf -y install make gcc \
+	&& microdnf -y install make gcc findutils \
 	&& microdnf clean all \
 	&& mkdir -p /compile \
 	&& useradd compile \
@@ -18,7 +18,8 @@ RUN	make -C /compile
 USER	root
 RUN	cd /compile \
 	&& mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
-	&& cp -v /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 dest/lib64 \
+	&& for i in $(ldd $COMMAND | grep / | xargs echo) ; do \
+	test -r "$i" && (mkdir -p dest/$(dirname $i) ; cp -v $i dest/$i) || true ; done \
 	&& cp -v /compile/$COMMAND dest/
 
 ## Stage 2 : Create the final container image

--- a/Containerfile
+++ b/Containerfile
@@ -9,16 +9,17 @@ RUN	(test -r /etc/dnf/plugins/subscription-manager.conf \
 	&& rm -f /etc/yum.repos.d/redhat.repo \ 
 	&& microdnf -y install make gcc \
 	&& microdnf clean all \
-	&& mkdir -p /compile
-RUN	ls -l && pwd
+	&& mkdir -p /compile \
+	&& useradd compile \
+	&& chown -Rc /compile
+USER	compile
 COPY	Makefile *.c *.h /compile/
-RUN	make --version
-RUN	gcc --version
 RUN	make -C /compile
-WORKDIR /compile
-RUN	mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
+USER	root
+RUN	cd /compile \
+	&& mkdir -p dest/bin dest/proc dest/sys dest/tmp dest/lib64 \
 	&& cp -v /lib64/libc.so.6 /lib64/ld-linux-x86-64.so.2 dest/lib64 \
-	&& cp -v $COMMAND dest/
+	&& cp -v /compile/$COMMAND dest/
 
 ## Stage 2 : Create the final container image
 FROM scratch


### PR DESCRIPTION
Spent a lot of time trying to figure out why quay wasn't building.

It was due to the container commands.

On the version of podman or docker that quay uses, the COPY command needs a slash / to copy multiple files to a directory.

However, on the version I have, it didn't require this.

```COPY    Makefile *.c *.h /compile/```

vs

```COPY    Makefile *.c *.h /compile```

There wasn't an error message when this happened except "Internal error"