### PR TITLE
Added code to randomize allocated memory contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # eatmemory
 Small program that I released in the Public Domain in 2003 to chew memory
 
+[![Docker Repository on Quay](https://quay.io/repository/gonoph/eatmemory/status "Docker Repository on Quay")](https://quay.io/repository/gonoph/eatmemory)
+
 # Build
 You should just need to run make:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Usage: eatmemory [ -f | --free] [ -m metabytes | --megs megabytes ] [ -q | --qui
     -f | --free  : attempt to only allocate free memory
     -m | --megs  : the number of megabytes to consume (default 50%)
                    when % is 100% or more, all available RAM will be consumed.
+    -r | --random: randomize buffer in order to prevent memory compression
     -q | --quiet : suppress output
     -h | --help  : this help screen
 
@@ -24,14 +25,15 @@ Usage: eatmemory [ -f | --free] [ -m metabytes | --megs megabytes ] [ -q | --qui
     EATMEGS      : alternative to -m / --megs
 ```
 
-This is what it looks like on MacOS 14 using the free parameter:
+This is what it looks like on MacOS 14 using the free and random parameters:
 ```bash
-./eatmemory -f
-Limiting to 50% of availble free memory: free=26; total=16384
-using 50% of available memory 26 megabytes for a target allocation of 13 megabytes
-Consuming 13 megabytes
-+ Created 13 megabytes
-+ Allocated 13631592 bytes
+$ ./eatmemory -f -r
+Limiting to 50% of availble free memory: free=121; total=16384
+using 50% of available memory 121 megabytes for a target allocation of 60 megabytes
+Consuming 60 megabytes
++ randomizing memory enabled
++ Created 60 megabytes
++ Allocated 62915040 bytes
 ++ Looped: 1
 ++ Looped: 2
 ++ Looped: 3

--- a/args.c
+++ b/args.c
@@ -14,6 +14,7 @@ static const struct option longopts[] = {
   { "megs",   required_argument, NULL, 'm' },
   { "help",   no_argument,       NULL, 'h' },
   { "quiet",  no_argument,       NULL, 'q' },
+  { "random", no_argument,       NULL, 'r' },
   { NULL,     0,                 NULL, 0 }
 };
 
@@ -24,6 +25,7 @@ void help(void) {
     -f | --free  : attempt to only allocate free memory\n\
     -m | --megs  : the number of megabytes to consume (default %s)\n\
                    when %% is 100%% or more, all available RAM will be consumed.\n\
+    -r | --random: randomize buffer in order to prevent memory compression\n\
     -q | --quiet : suppress output\n\
     -h | --help  : this help screen\n\
 \n\
@@ -66,7 +68,7 @@ void parse_megabytes(const char *source) {
 int argparse(int argc, char **argv) {
     int ch;
     char * saved_arg_megs = NULL;
-    while ((ch = getopt_long(argc, argv, "fhqm:", longopts, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "fhqm:r", longopts, NULL)) != -1) {
         switch (ch) {
             case 'f':
                 eat_flags.flag_free = 1;
@@ -76,6 +78,10 @@ int argparse(int argc, char **argv) {
                 break;
             case 'm':
                 saved_arg_megs = (char*)strdup(optarg);
+                break;
+            case 'r':
+                srandomdev();
+                eat_flags.flag_random = 1;
                 break;
             case 'h':
             default:

--- a/args.c
+++ b/args.c
@@ -65,6 +65,12 @@ void parse_megabytes(const char *source) {
     eat_flags.megs = megabytes;
 }
 
+#ifdef __linux__
+#include <time.h>
+// this is only defined on BSD type system
+#define srandomdev()    srandom(time(NULL))
+#endif
+
 int argparse(int argc, char **argv) {
     int ch;
     char * saved_arg_megs = NULL;

--- a/eatmemory.c
+++ b/eatmemory.c
@@ -35,7 +35,7 @@ int main(int argc,char **argv)
     info("Consuming %u megabytes\n", eat_flags.megs);
 
     if (eat_flags.flag_random)
-        info("+ randomizing memory enabled\n");
+        info("+ enabled randomizing memory\n");
 
     if (sys_info_cgroup)
         info("+ detected running in a cgroup with memory limits.\n");
@@ -53,19 +53,23 @@ int main(int argc,char **argv)
      * especially if it starts to swap */
 
     unsigned int counter = 0;
+    unsigned long refresh = 0;
     for (;;)
     {
+        if (eat_flags.flag_random) {
+            refresh = mksalt();
+        };
         for (looper1=0;looper1<eat_flags.megs;looper1++)
         {
             if (eat_flags.flag_random) {
                 unsigned long * lbuff = (unsigned long*) bigarray[looper1];
                 int max = CHUNK / sizeof(unsigned long);
                 for (int i = 0; i < max; i++) {
-                    *lbuff = mksalt();
+                    *lbuff = *lbuff ^ refresh;
                     lbuff++;
                 }
             } else {
-                memset(bigarray[looper1],48+(512 % 10),CHUNK);      /* just picked something random to throw in there */
+                memset(bigarray[looper1],'A' + (looper1 % 26) ,CHUNK); 
             }
             FD_ZERO(&empty_stdin);
             FD_ZERO(&empty_stdout);

--- a/eatmemory.c
+++ b/eatmemory.c
@@ -19,7 +19,7 @@
 
 const int CHUNK = 1 << 20;
 
-eat_flags_t eat_flags = { 0, 0, 0, 0, 0, 0L, 0L };
+eat_flags_t eat_flags = { 0, 0, 0, 0, 0, 0, 0L, 0L };
 
 int main(int argc,char **argv)
 {
@@ -33,6 +33,9 @@ int main(int argc,char **argv)
     argparse(argc, argv);
 
     info("Consuming %u megabytes\n", eat_flags.megs);
+
+    if (eat_flags.flag_random)
+        info("+ randomizing memory enabled\n");
 
     if (sys_info_cgroup)
         info("+ detected running in a cgroup with memory limits.\n");
@@ -54,7 +57,16 @@ int main(int argc,char **argv)
     {
         for (looper1=0;looper1<eat_flags.megs;looper1++)
         {
-            memset(bigarray[looper1],48+(512 % 10),CHUNK);      /* just picked something random to throw in there */
+            if (eat_flags.flag_random) {
+                unsigned long * lbuff = (unsigned long*) bigarray[looper1];
+                int max = CHUNK / sizeof(unsigned long);
+                for (int i = 0; i < max; i++) {
+                    *lbuff = mksalt();
+                    lbuff++;
+                }
+            } else {
+                memset(bigarray[looper1],48+(512 % 10),CHUNK);      /* just picked something random to throw in there */
+            }
             FD_ZERO(&empty_stdin);
             FD_ZERO(&empty_stdout);
             FD_ZERO(&empty_stderr);

--- a/eatmemory.h
+++ b/eatmemory.h
@@ -10,6 +10,7 @@ struct eat_flags_s {
   int flag_pct;
   int flag_quiet;
   int flag_free;
+  int flag_random;
   int cgroup;
   unsigned long memtotal;
   unsigned long allocated;

--- a/error.h
+++ b/error.h
@@ -7,6 +7,6 @@
 
 #define err(...) {fprintf(stderr, __VA_ARGS__); if (errno > 0) perror(NULL); exit(-1);}
 #define perr(msg) {perror(msg); exit(-1);}
-#define info(...) {if (!eat_flags.flag_quiet) printf(__VA_ARGS__);}
+#define info(...) {if (!eat_flags.flag_quiet) printf(__VA_ARGS__);fflush(stdout);}
 
 #endif

--- a/malloc.c
+++ b/malloc.c
@@ -17,6 +17,14 @@ char **CreateLargeArray(unsigned long megs)
     return(largearray);
 }
 
+// return a full unsigned long random number
+unsigned long mksalt(void) {
+    unsigned long salt;
+    salt = (unsigned long) random() << 32;
+    salt += (unsigned long) random();
+    return salt;
+}
+
 char **CreateLargeChunk(unsigned long chunks,char **largearray)
 {
     unsigned long looper1;
@@ -36,8 +44,18 @@ char **CreateLargeChunk(unsigned long chunks,char **largearray)
             err("[error] Unable to malloc() %lu chunks.\n", chunks);
     }
 
-    /* set the memory to ascii(48) '0' */
-    memset(largearray[looper1],'0',CHUNK);
+    if (eat_flags.flag_random) {
+        // randomize the memory chunk
+        unsigned long * lbuff = (unsigned long*) largearray[looper1];
+        int max = CHUNK / sizeof(unsigned long);
+        for (int i = 0; i < max; i++) {
+            *lbuff = mksalt();
+            lbuff++;
+        }
+    } else {
+        /* set the memory to ascii(48) '0' */
+        memset(largearray[looper1],'0',CHUNK);
+    }
 
     eat_flags.allocated += CHUNK;
     }

--- a/malloc.h
+++ b/malloc.h
@@ -3,5 +3,6 @@
 
 char **CreateLargeArray(unsigned long megs);
 char **CreateLargeChunk(unsigned long chunks,char **largearray);
+unsigned long mksalt(void);
 
 #endif


### PR DESCRIPTION
Darwin / MacOS is able to compress memory, so this addition should ensure the memory is unable to be compressed.